### PR TITLE
HX3圧縮受信(H.264/HEVC + MediaCodec)経路の実装と現状整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,45 @@
 
 Android端末でNDI HX3ストリームを受信・表示するアプリケーションです。
 
+---
+
+## ⚠️ 現状ステータス（2026-06-04 時点）
+
+実機（Pixel 7a / Android）での検証を行い、現在地を整理しました。
+
+| 項目 | 状態 |
+|------|------|
+| ビルド（標準SDK同梱・arm64-v8a） | ✅ 成功（`assembleDebug`） |
+| 実機インストール・起動 | ✅ 成功（クラッシュなし） |
+| NDIソース検出（mDNS） | ✅ 成功 |
+| **非圧縮NDI（BGRA）受信・表示** | ✅ **実機で表示確認済み**（Macのテスト送信機から1280×720 BGRA @30fpsを受信・描画） |
+| 切断・再接続 | ✅ 安定 |
+| 単体テスト（圧縮パケット解析ほか） | ✅ 全通過（`testDebugUnitTest`） |
+| **NDI|HX3（圧縮H.264/HEVC）受信** | ⛔ **未検証**。下記の理由により、現状の同梱SDKでは黒画面になります |
+
+### HX3が現状動かない理由（重要）
+
+このリポジトリに同梱されている `libndi.so` は **無料の標準NDI SDK（v5.6.1）** です。
+**標準SDKはアプリへ圧縮H.264/HEVCデータを渡せず、デコード済みピクセルしか返しません。**
+NDI|HX3の「圧縮パススルー＆デコード」は **NDI Advanced SDK 専用機能** です（公式FAQで明言）。
+
+したがってHX3を正しく受信するには、**NDI Advanced SDK の入手（申請が必要）** が前提になります。
+
+- 開発・評価目的の Advanced SDK は **無料**（申請フォームでの登録・規約同意が必要）
+- ライセンス費用が関わるのは **完成品を商用配布する段階のみ**（`sdk@ndi.video` でvendor ID取得）
+- 申請: https://ndi.video/for-developers/ndi-advanced/
+
+### 何が実装済みで、何が未確認か
+
+- ✅ 圧縮パススルー受信のコード経路はこのブランチで**実装済み**：
+  受信カラーフォーマットの切替（`COMPRESSED_V5`）、`NDIlib_compressed_packet_t` の解析（Annex-B組み立て・キーフレーム判定・コーデック判別）、MediaCodecへの配線、単体テスト。
+- ⛔ ただし **Advanced SDKの入手・差し替えが未完のため、実機でのHX3受信テストは未実施**です。
+  申請許可が下りてAdvanced SDKを組み込んだ後の動作確認は**まだ行えていません**。
+
+> 👉 HX3を有効化する手順は **[docs/HX3-INTEGRATION.md](docs/HX3-INTEGRATION.md)** に全手順をまとめてあります。
+
+---
+
 ## 機能
 
 - **NDIソース検出**: ネットワーク上のNDIソースを自動検出
@@ -18,7 +57,8 @@ Android端末でNDI HX3ストリームを受信・表示するアプリケーシ
 
 - Android 8.0 (API 26) 以上
 - arm64-v8a デバイス
-- NDI SDK v6 対応ソース
+- 非圧縮NDIソース：標準SDKで受信可
+- **NDI|HX3（圧縮）ソース：NDI Advanced SDK が必要**（[docs/HX3-INTEGRATION.md](docs/HX3-INTEGRATION.md) 参照）
 
 ## インストール
 
@@ -28,11 +68,12 @@ Android端末でNDI HX3ストリームを受信・表示するアプリケーシ
 
 ## ビルド方法
 
-### 前提条件
+### 前提条件（検証済みツールチェーン）
 
-- Android Studio (最新版推奨)
-- NDK
-- NDI SDK v6 for Android
+- Android SDK Platform 34 / Build-Tools 34 / Platform 35
+- NDK `26.1.10909125`、CMake `3.22.1`
+- JDK 17〜21（AGP 8.2.2 / Gradle 8.5。検証は OpenJDK 21 で実施）
+- 同梱の `libndi.so`（標準SDK v5.6.1）で非圧縮NDIはビルド・受信可能
 
 ### 手順
 
@@ -42,11 +83,18 @@ git clone https://github.com/mackatwentytsuru/Android-NDI-HX3.git
 cd Android-NDI-HX3
 ```
 
-2. NDI SDKをダウンロードして配置
-   - [NDI SDK](https://ndi.video/) からAndroid版をダウンロード
-   - `libndi.so` を `app/src/main/jniLibs/arm64-v8a/` に配置
+2. NDI SDKを配置
+   - 非圧縮のみ：標準 [NDI SDK](https://ndi.video/) の `libndi.so` を `app/src/main/jniLibs/arm64-v8a/` に配置（リポジトリに同梱済み）
+   - **HX3（圧縮）対応**：[NDI Advanced SDK](https://ndi.video/for-developers/ndi-advanced/) を申請・入手し、その `libndi.so` で置き換え＋ヘッダ更新 → **[docs/HX3-INTEGRATION.md](docs/HX3-INTEGRATION.md)** の手順を実施
 
-3. Android Studioで開いてビルド
+3. ビルド
+```bash
+# CLI（検証済み）
+echo "sdk.dir=$HOME/Library/Android/sdk" > local.properties   # 環境に合わせて
+./gradlew assembleDebug          # APK: app/build/outputs/apk/debug/app-debug.apk
+./gradlew testDebugUnitTest      # 単体テスト
+# もしくは Android Studio で開いてビルド
+```
 
 ## アーキテクチャ
 

--- a/app/src/main/cpp/ndi_wrapper.c
+++ b/app/src/main/cpp/ndi_wrapper.c
@@ -29,9 +29,24 @@
 #define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
-/* Kotlin FourCC constants for compressed frames. */
-static const uint32_t FOURCC_H264 = 0x34363248; /* 'H264' */
-static const uint32_t FOURCC_HEVC = 0x43564548; /* 'HEVC' */
+/* Kotlin FourCC constants for compressed frames.
+ *
+ * NDI signals the compressed bandwidth tier via the case of the FourCC:
+ *   uppercase 'H264'/'HEVC' = highest_bandwidth (full resolution)
+ *   lowercase 'h264'/'hevc' = lowest_bandwidth  (preview substream)
+ * We accept both so compressed passthrough works regardless of tier. */
+static const uint32_t FOURCC_H264         = 0x34363248; /* 'H264' highest bandwidth */
+static const uint32_t FOURCC_HEVC         = 0x43564548; /* 'HEVC' highest bandwidth */
+static const uint32_t FOURCC_H264_LOWBAND = 0x34363268; /* 'h264' lowest bandwidth  */
+static const uint32_t FOURCC_HEVC_LOWBAND = 0x63766568; /* 'hevc' lowest bandwidth  */
+
+/* NDI Advanced SDK compressed-passthrough receive color format.
+ * Not present in the free/standard SDK header, so we use the documented numeric
+ * value. With the standard libndi.so this value is ignored (the SDK falls back
+ * to a default); with the Advanced SDK libndi.so it delivers H.264/HEVC frames
+ * as NDIlib_compressed_packet_t which the app decodes via Android MediaCodec.
+ * Source: Processing.NDI.Advanced.h -> NDIlib_recv_color_format_compressed_v5 = 307. */
+#define NDI_RECV_COLOR_FORMAT_COMPRESSED_V5 307
 
 /* ============================================================================
  * Global State
@@ -130,6 +145,8 @@ static NDIlib_recv_color_format_e map_color_format(jint colorFormat) {
         case 3: return NDIlib_recv_color_format_UYVY_RGBA;
         case 100: return NDIlib_recv_color_format_fastest;
         case 101: return NDIlib_recv_color_format_best;
+        /* Compressed H.264/HEVC passthrough (NDI Advanced SDK only). */
+        case 200: return (NDIlib_recv_color_format_e)NDI_RECV_COLOR_FORMAT_COMPRESSED_V5;
         default: return NDIlib_recv_color_format_UYVY_BGRA;
     }
 }
@@ -652,7 +669,8 @@ Java_com_example_ndireceiver_ndi_NdiNative_receiverCaptureVideo(
     }
 
     const uint32_t fourcc = (uint32_t)handle->frame.FourCC;
-    const bool is_compressed = (fourcc == FOURCC_H264) || (fourcc == FOURCC_HEVC);
+    const bool is_compressed = (fourcc == FOURCC_H264) || (fourcc == FOURCC_HEVC) ||
+                               (fourcc == FOURCC_H264_LOWBAND) || (fourcc == FOURCC_HEVC_LOWBAND);
 
     if (handle->frame.p_data == NULL) {
         LOGW("receiverCaptureVideo: Video frame had NULL p_data");

--- a/app/src/main/java/com/example/ndireceiver/media/VideoDecoder.kt
+++ b/app/src/main/java/com/example/ndireceiver/media/VideoDecoder.kt
@@ -33,6 +33,12 @@ class VideoDecoder {
     @Volatile
     private var isRunning = false
 
+    // A compressed stream is only decodable starting from a keyframe (the
+    // keyframe carries the SPS/PPS/VPS codec config). Drop everything until the
+    // first one arrives, otherwise MediaCodec errors on the leading delta frames.
+    @Volatile
+    private var sawKeyframe = false
+
     private val frameQueue = LinkedBlockingQueue<VideoFrameData>(MAX_QUEUE_SIZE)
 
     private var currentWidth = 0
@@ -89,6 +95,9 @@ class VideoDecoder {
             start()
         }
 
+        // New decoder instance must re-sync to a keyframe before decoding.
+        sawKeyframe = false
+
         Log.i(TAG, "Decoder created: $mimeType ${width}x${height}")
     }
 
@@ -116,6 +125,14 @@ class VideoDecoder {
      */
     fun submitFrame(frame: VideoFrameData) {
         if (!isRunning) return
+
+        // Wait for the first keyframe before feeding the decoder.
+        if (!sawKeyframe) {
+            if (!frame.isKeyframe) {
+                return
+            }
+            sawKeyframe = true
+        }
 
         lastFrameRateN = frame.frameRateN
         lastFrameRateD = frame.frameRateD
@@ -148,12 +165,17 @@ class VideoDecoder {
                     data.rewind()
                     inputBuffer.put(data)
 
+                    val flags = if (frame.isKeyframe) {
+                        MediaCodec.BUFFER_FLAG_KEY_FRAME
+                    } else {
+                        0
+                    }
                     decoder?.queueInputBuffer(
                         inputIndex,
                         0,
                         data.limit(),
                         frame.timestamp,
-                        0
+                        flags
                     )
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/example/ndireceiver/ndi/FourCC.kt
+++ b/app/src/main/java/com/example/ndireceiver/ndi/FourCC.kt
@@ -24,6 +24,9 @@ enum class FourCC {
                 NdiNative.FourCC.I420 -> I420
                 NdiNative.FourCC.H264 -> H264
                 NdiNative.FourCC.HEVC -> HEVC
+                // NDI|HX low-bandwidth (preview) tier uses lowercase FourCCs.
+                NdiNative.FourCC.H264_LOW -> H264
+                NdiNative.FourCC.HEVC_LOW -> HEVC
                 else -> UNKNOWN
             }
         }

--- a/app/src/main/java/com/example/ndireceiver/ndi/NdiCompressedPacket.kt
+++ b/app/src/main/java/com/example/ndireceiver/ndi/NdiCompressedPacket.kt
@@ -1,0 +1,133 @@
+package com.example.ndireceiver.ndi
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Parser for `NDIlib_compressed_packet_t` — the container the NDI **Advanced SDK**
+ * uses to deliver compressed H.264 / HEVC (NDI|HX, HX3) video to the application.
+ *
+ * When the receiver is created with [NdiNative.ColorFormat.COMPRESSED_V5], each
+ * captured video frame's `p_data` points at this packet instead of raw pixels.
+ * This parser turns it into a MediaCodec-ready Annex-B byte stream.
+ *
+ * Wire format (little-endian, `#pragma pack(1)`, 44-byte header, no padding):
+ * ```
+ * offset  type      field
+ *  0      int32     version            (== header size, currently 44)
+ *  4      uint32    fourCC             ('H264' or 'HEVC')
+ *  8      int64     pts                (100ns units)
+ * 16      int64     dts                (100ns units)
+ * 24      uint64    reserved
+ * 32      uint32    flags              (bit 0 = keyframe / I-frame)
+ * 36      uint32    data_size          (bytes of compressed payload)
+ * 40      uint32    extra_data_size    (bytes of codec config; I-frames only)
+ * 44      ...       [ data ][ extra_data ]   (in that order)
+ * ```
+ * Both `data` and `extra_data` are **Annex-B** (NAL units delimited by
+ * `00 00 00 01` start codes). `extra_data` holds the codec configuration as
+ * concatenated Annex-B parameter sets — H.264: SPS, PPS; HEVC: VPS, SPS, PPS —
+ * and is present only on keyframes.
+ *
+ * Source: Processing.NDI.Advanced.h (NDIlib_compressed_packet_t, version_0 = 44)
+ * and docs.ndi.video "Using H.264, H.265, and AAC Codecs".
+ */
+object NdiCompressedPacket {
+
+    /** Size of the fixed packet header in bytes (NDIlib_compressed_packet_version_0). */
+    const val HEADER_SIZE = 44
+
+    private const val FLAG_KEYFRAME = 0x1
+
+    // Header field offsets.
+    private const val OFF_VERSION = 0
+    private const val OFF_FOURCC = 4
+    private const val OFF_FLAGS = 32
+    private const val OFF_DATA_SIZE = 36
+    private const val OFF_EXTRA_SIZE = 40
+
+    /**
+     * Result of parsing one compressed packet.
+     *
+     * @property codec [FourCC.H264] or [FourCC.HEVC].
+     * @property isKeyframe true when this is an I-frame (carries codec config).
+     * @property annexB MediaCodec-ready Annex-B stream. On a keyframe this is
+     *   `extra_data + data` (config NALs first, as MediaCodec requires); on a
+     *   delta frame it is `data` only. Always a freshly allocated copy, so it
+     *   stays valid after the native NDI frame is freed.
+     */
+    data class CompressedFrame(
+        val codec: FourCC,
+        val isKeyframe: Boolean,
+        val annexB: ByteArray
+    ) {
+        // ByteArray needs explicit equals/hashCode for a value-like data class.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is CompressedFrame) return false
+            return codec == other.codec &&
+                isKeyframe == other.isKeyframe &&
+                annexB.contentEquals(other.annexB)
+        }
+
+        override fun hashCode(): Int {
+            var result = codec.hashCode()
+            result = 31 * result + isKeyframe.hashCode()
+            result = 31 * result + annexB.contentHashCode()
+            return result
+        }
+    }
+
+    /**
+     * Parse a compressed NDI video packet.
+     *
+     * @param buffer the frame buffer from native (position/limit are not mutated).
+     * @return the parsed frame, or null if the buffer is too small, the sizes are
+     *   inconsistent, or the codec is not H.264/HEVC.
+     */
+    fun parse(buffer: ByteBuffer): CompressedFrame? {
+        val buf = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN)
+        val base = buf.position()
+        val total = buf.remaining()
+        if (total < HEADER_SIZE) return null
+
+        val version = buf.getInt(base + OFF_VERSION)
+        val fourCC = buf.getInt(base + OFF_FOURCC)
+        val flags = buf.getInt(base + OFF_FLAGS)
+        val dataSize = buf.getInt(base + OFF_DATA_SIZE)
+        val extraSize = buf.getInt(base + OFF_EXTRA_SIZE)
+
+        // The payload starts at `version` bytes in (forward-compatible if the
+        // header ever grows); never less than the known header size.
+        val headerLen = if (version >= HEADER_SIZE) version else HEADER_SIZE
+        if (dataSize < 0 || extraSize < 0) return null
+
+        val dataStart = base + headerLen
+        val extraStart = dataStart + dataSize
+        // Everything must fit inside the buffer.
+        if (headerLen > total) return null
+        if (extraStart + extraSize > base + total) return null
+
+        val codec = when (fourCC) {
+            NdiNative.FourCC.H264, NdiNative.FourCC.H264_LOW -> FourCC.H264
+            NdiNative.FourCC.HEVC, NdiNative.FourCC.HEVC_LOW -> FourCC.HEVC
+            else -> return null
+        }
+
+        val isKeyframe = (flags and FLAG_KEYFRAME) != 0
+        val includeExtra = isKeyframe && extraSize > 0
+
+        val out = ByteArray(if (includeExtra) extraSize + dataSize else dataSize)
+        var offset = 0
+        // MediaCodec needs config NALs (SPS/PPS/VPS) BEFORE the frame data.
+        if (includeExtra) {
+            buf.position(extraStart)
+            buf.get(out, offset, extraSize)
+            offset += extraSize
+        }
+        buf.position(dataStart)
+        buf.get(out, offset, dataSize)
+
+        return CompressedFrame(codec, isKeyframe, out)
+    }
+}

--- a/app/src/main/java/com/example/ndireceiver/ndi/NdiNative.kt
+++ b/app/src/main/java/com/example/ndireceiver/ndi/NdiNative.kt
@@ -321,6 +321,12 @@ object NdiNative {
         const val UYVY_RGBA = 3
         const val FASTEST = 100  // Let NDI choose fastest format
         const val BEST = 101     // Let NDI choose best quality format
+
+        // Compressed H.264/HEVC passthrough for NDI|HX (HX3) hardware decode.
+        // Maps in the native wrapper to NDIlib_recv_color_format_compressed_v5 (=307).
+        // REQUIRES the NDI Advanced SDK libndi.so; ignored by the free/standard SDK.
+        // See docs/HX3-INTEGRATION.md.
+        const val COMPRESSED_V5 = 200
     }
 
     object FourCC {
@@ -331,7 +337,9 @@ object NdiNative {
         const val RGBX = 0x58424752  // 'RGBX' - 32-bit RGB (no alpha)
         const val NV12 = 0x3231564E  // 'NV12' - YUV 4:2:0 planar
         const val I420 = 0x30323449  // 'I420' - YUV 4:2:0 planar
-        const val H264 = 0x34363248  // 'H264' - Compressed H.264
-        const val HEVC = 0x43564548  // 'HEVC' - Compressed H.265
+        const val H264 = 0x34363248  // 'H264' - Compressed H.264 (highest bandwidth)
+        const val HEVC = 0x43564548  // 'HEVC' - Compressed H.265 (highest bandwidth)
+        const val H264_LOW = 0x34363268  // 'h264' - Compressed H.264 (lowest bandwidth / preview)
+        const val HEVC_LOW = 0x63766568  // 'hevc' - Compressed H.265 (lowest bandwidth / preview)
     }
 }

--- a/app/src/main/java/com/example/ndireceiver/ndi/NdiReceiver.kt
+++ b/app/src/main/java/com/example/ndireceiver/ndi/NdiReceiver.kt
@@ -33,7 +33,9 @@ data class VideoFrameData(
     val lineStrideBytes: Int,
     val timestamp: Long,
     val fourCC: FourCC,
-    val isCompressed: Boolean = false
+    val isCompressed: Boolean = false,
+    /** For compressed frames: true when this is an I-frame (carries codec config). */
+    val isKeyframe: Boolean = false
 )
 
 /**
@@ -60,6 +62,23 @@ class NdiReceiver {
         private const val THREAD_JOIN_TIMEOUT_MS = 3000L
         private const val SYNC_JOIN_TIMEOUT_MS = 500L // Short timeout for sync disconnect
         private const val CONNECTION_LOST_THRESHOLD = 5
+
+        /**
+         * NDI|HX (HX3) compressed-passthrough mode.
+         *
+         * When false (default): the receiver requests decoded BGRA pixels
+         * (BGRX_BGRA). This is correct for full-bandwidth/uncompressed NDI and
+         * is the only mode the free/standard SDK can serve. HX3 sources show a
+         * black screen in this mode because the standard SDK lacks the HX
+         * decode libraries.
+         *
+         * When true: the receiver requests compressed H.264/HEVC passthrough
+         * (COMPRESSED_V5) so HX3 frames are decoded on-device with MediaCodec.
+         * This REQUIRES the NDI Advanced SDK libndi.so to be installed in
+         * jniLibs — see docs/HX3-INTEGRATION.md. Do not enable it with the
+         * standard SDK or reception will fall back to defaults.
+         */
+        const val USE_COMPRESSED_HX = false
     }
 
     // Use AtomicLong for thread-safe access to receiver pointer
@@ -114,11 +133,17 @@ class NdiReceiver {
         consecutiveNullFrames = 0
 
         try {
-            // Create receiver
+            // Create receiver. In HX3 mode we ask the SDK for compressed
+            // H.264/HEVC passthrough; otherwise decoded BGRA pixels.
+            val colorFormat = if (USE_COMPRESSED_HX) {
+                NdiNative.ColorFormat.COMPRESSED_V5
+            } else {
+                NdiNative.ColorFormat.BGRX_BGRA
+            }
             val newPtr = NdiNative.receiverCreate(
                 receiverName = "Android NDI Receiver",
                 bandwidth = NdiNative.Bandwidth.HIGHEST,
-                colorFormat = NdiNative.ColorFormat.BGRX_BGRA,
+                colorFormat = colorFormat,
                 allowVideoFields = true
             )
 
@@ -178,19 +203,44 @@ class NdiReceiver {
                         val isCompressed = fourCC == FourCC.H264 ||
                                           fourCC == FourCC.HEVC
 
-                        val frameData = VideoFrameData(
-                            width = videoFrame.width,
-                            height = videoFrame.height,
-                            frameRateN = videoFrame.frameRateN,
-                            frameRateD = videoFrame.frameRateD,
-                            data = videoFrame.data,
-                            lineStrideBytes = videoFrame.lineStrideBytes,
-                            timestamp = videoFrame.timestamp,
-                            fourCC = fourCC,
-                            isCompressed = isCompressed
-                        )
+                        val frameData = if (isCompressed) {
+                            // HX3: the native buffer is an NDIlib_compressed_packet_t.
+                            // Parse it into a MediaCodec-ready Annex-B copy that
+                            // outlives the native frame (decoding is asynchronous).
+                            NdiCompressedPacket.parse(videoFrame.data)?.let { pkt ->
+                                VideoFrameData(
+                                    width = videoFrame.width,
+                                    height = videoFrame.height,
+                                    frameRateN = videoFrame.frameRateN,
+                                    frameRateD = videoFrame.frameRateD,
+                                    data = ByteBuffer.wrap(pkt.annexB),
+                                    lineStrideBytes = 0,
+                                    timestamp = videoFrame.timestamp,
+                                    fourCC = pkt.codec,
+                                    isCompressed = true,
+                                    isKeyframe = pkt.isKeyframe
+                                )
+                            }
+                        } else {
+                            // Uncompressed: pass the direct buffer through; the
+                            // renderer copies it synchronously inside the callback,
+                            // before we free the native frame below.
+                            VideoFrameData(
+                                width = videoFrame.width,
+                                height = videoFrame.height,
+                                frameRateN = videoFrame.frameRateN,
+                                frameRateD = videoFrame.frameRateD,
+                                data = videoFrame.data,
+                                lineStrideBytes = videoFrame.lineStrideBytes,
+                                timestamp = videoFrame.timestamp,
+                                fourCC = fourCC,
+                                isCompressed = false
+                            )
+                        }
 
-                        frameCallback?.onVideoFrame(frameData)
+                        if (frameData != null) {
+                            frameCallback?.onVideoFrame(frameData)
+                        }
 
                         // Free the frame - check pointer is still valid
                         val currentPtr = receiverPtrAtomic.get()

--- a/app/src/test/java/com/example/ndireceiver/ndi/NdiCompressedPacketTest.kt
+++ b/app/src/test/java/com/example/ndireceiver/ndi/NdiCompressedPacketTest.kt
@@ -1,0 +1,130 @@
+package com.example.ndireceiver.ndi
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Unit tests for [NdiCompressedPacket], the NDIlib_compressed_packet_t parser.
+ *
+ * These verify the byte-level parsing against the documented Advanced SDK wire
+ * format (44-byte little-endian header, `[header][data][extra_data]`, Annex-B
+ * payloads). This is the one piece of HX3 logic that can be tested without the
+ * Advanced SDK or live hardware.
+ */
+class NdiCompressedPacketTest {
+
+    private val FOURCC_H264 = 0x34363248 // 'H264'
+    private val FOURCC_HEVC = 0x43564548 // 'HEVC'
+
+    /**
+     * Build a packet buffer: [44-byte header][data][extraData].
+     */
+    private fun packet(
+        fourCC: Int,
+        flags: Int,
+        data: ByteArray,
+        extraData: ByteArray,
+        version: Int = NdiCompressedPacket.HEADER_SIZE,
+        // allow forcing an inconsistent declared size for negative tests
+        declaredDataSize: Int = data.size,
+        declaredExtraSize: Int = extraData.size
+    ): ByteBuffer {
+        val buf = ByteBuffer
+            .allocate(NdiCompressedPacket.HEADER_SIZE + data.size + extraData.size)
+            .order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(version)            // 0  version
+        buf.putInt(fourCC)             // 4  fourCC
+        buf.putLong(0L)                // 8  pts
+        buf.putLong(0L)                // 16 dts
+        buf.putLong(0L)                // 24 reserved
+        buf.putInt(flags)              // 32 flags
+        buf.putInt(declaredDataSize)   // 36 data_size
+        buf.putInt(declaredExtraSize)  // 40 extra_data_size
+        buf.put(data)                  // 44 data
+        buf.put(extraData)             //    extra_data
+        buf.rewind()
+        return buf
+    }
+
+    @Test
+    fun `keyframe prepends extra data before frame data`() {
+        val data = byteArrayOf(0, 0, 0, 1, 0x65, 0x11, 0x22) // IDR slice (Annex-B)
+        val extra = byteArrayOf(0, 0, 0, 1, 0x67, 0, 0, 0, 1, 0x68) // SPS + PPS
+
+        val frame = NdiCompressedPacket.parse(packet(FOURCC_H264, 1, data, extra))!!
+
+        assertEquals(FourCC.H264, frame.codec)
+        assertTrue(frame.isKeyframe)
+        // MediaCodec needs config NALs first: extra_data + data.
+        assertArrayEquals(extra + data, frame.annexB)
+    }
+
+    @Test
+    fun `delta frame contains only frame data`() {
+        val data = byteArrayOf(0, 0, 0, 1, 0x41, 0x33, 0x44) // non-IDR slice
+
+        val frame = NdiCompressedPacket.parse(packet(FOURCC_H264, 0, data, ByteArray(0)))!!
+
+        assertEquals(FourCC.H264, frame.codec)
+        assertFalse(frame.isKeyframe)
+        assertArrayEquals(data, frame.annexB)
+    }
+
+    @Test
+    fun `recognizes HEVC fourCC`() {
+        val data = byteArrayOf(0, 0, 0, 1, 0x26)
+        val extra = byteArrayOf(0, 0, 0, 1, 0x40) // VPS
+
+        val frame = NdiCompressedPacket.parse(packet(FOURCC_HEVC, 1, data, extra))!!
+
+        assertEquals(FourCC.HEVC, frame.codec)
+        assertArrayEquals(extra + data, frame.annexB)
+    }
+
+    @Test
+    fun `keyframe flag is read from bit 0 only`() {
+        val data = byteArrayOf(1, 2, 3)
+        // flags with bit0 set among other bits.
+        val frame = NdiCompressedPacket.parse(packet(FOURCC_H264, 0x7, data, byteArrayOf(9)))!!
+        assertTrue(frame.isKeyframe)
+
+        val delta = NdiCompressedPacket.parse(packet(FOURCC_H264, 0x6, data, ByteArray(0)))!!
+        assertFalse(delta.isKeyframe)
+    }
+
+    @Test
+    fun `returns null when buffer smaller than header`() {
+        val tooSmall = ByteBuffer.allocate(10).order(ByteOrder.LITTLE_ENDIAN)
+        assertNull(NdiCompressedPacket.parse(tooSmall))
+    }
+
+    @Test
+    fun `returns null when declared sizes exceed buffer`() {
+        val data = byteArrayOf(1, 2, 3)
+        // Claim more data than is actually present.
+        val bad = packet(FOURCC_H264, 1, data, ByteArray(0), declaredDataSize = 9999)
+        assertNull(NdiCompressedPacket.parse(bad))
+    }
+
+    @Test
+    fun `returns null for unknown codec`() {
+        val data = byteArrayOf(1, 2, 3)
+        val aac = 0x00ff
+        assertNull(NdiCompressedPacket.parse(packet(aac, 1, data, ByteArray(0))))
+    }
+
+    @Test
+    fun `does not consume the source buffer position`() {
+        val data = byteArrayOf(0, 0, 0, 1, 0x41)
+        val buf = packet(FOURCC_H264, 0, data, ByteArray(0))
+        val posBefore = buf.position()
+        NdiCompressedPacket.parse(buf)
+        assertEquals(posBefore, buf.position())
+    }
+}

--- a/app/src/test/java/com/example/ndireceiver/ui/player/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/example/ndireceiver/ui/player/PlayerViewModelTest.kt
@@ -3,6 +3,7 @@ package com.example.ndireceiver.ui.player
 import android.app.Application
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.example.ndireceiver.ndi.ConnectionState
+import com.example.ndireceiver.ndi.FourCC
 import com.example.ndireceiver.ndi.NdiNative
 import com.example.ndireceiver.ndi.VideoFrameData
 import io.mockk.*
@@ -152,7 +153,7 @@ class PlayerViewModelTest {
             data = buffer,
             lineStrideBytes = 1920 * 4,
             timestamp = 0L,
-            fourCC = NdiNative.FourCC.BGRA,
+            fourCC = FourCC.BGRA,
             isCompressed = false
         )
 
@@ -172,7 +173,7 @@ class PlayerViewModelTest {
             data = buffer,
             lineStrideBytes = 0,
             timestamp = 0L,
-            fourCC = NdiNative.FourCC.H264,
+            fourCC = FourCC.H264,
             isCompressed = true
         )
 
@@ -190,7 +191,7 @@ class PlayerViewModelTest {
             data = buffer,
             lineStrideBytes = 0,
             timestamp = 0L,
-            fourCC = NdiNative.FourCC.HEVC,
+            fourCC = FourCC.HEVC,
             isCompressed = true
         )
 

--- a/docs/HX3-INTEGRATION.md
+++ b/docs/HX3-INTEGRATION.md
@@ -1,0 +1,140 @@
+# NDI|HX3 受信 統合ガイド
+
+このドキュメントは、本アプリで **NDI|HX3（圧縮 H.264/HEVC）ストリームを実機で正しく受信** するために必要な作業をまとめたものです。
+
+最終更新: 2026-06-04
+
+---
+
+## 0. 結論（なぜ申請が必要か）
+
+| SDK | HX3圧縮データをアプリに渡せるか | 入手 |
+|-----|------------------------------|------|
+| 標準NDI SDK（無料・**同梱中** v5.6.1） | ❌ 不可（デコード済みピクセルのみ） | 即DL |
+| **NDI Advanced SDK** | ✅ 可（H.264/HEVCパススルー） | **申請が必要** |
+
+> 標準SDKはHX3の圧縮ストリームをアプリへ渡せないため、現状のビルドではHX3ソースは**黒画面**になります（公式FAQで明言されている仕様）。HX3対応には Advanced SDK が必須です。
+
+**費用**: 開発・評価用の Advanced SDK は **無料**（申請フォームでの登録・規約同意が必要）。ライセンス費用は **商用配布段階のみ**（`sdk@ndi.video` で vendor ID 取得）。本アプリはプライベートプロジェクトのため、開発・自己利用の範囲では費用は発生しません。
+
+---
+
+## 1. Advanced SDK の申請・入手
+
+1. https://ndi.video/for-developers/ndi-advanced/ にアクセスし、Advanced SDK（トライアル/開発用）を申請
+2. 案内に従い **Android版** と、テストソース作成用に **Apple版（macOS）** を入手
+3. Android Advanced SDK には以下が含まれます：
+   - ABIごとの `libndi.so`（`arm64-v8a` ほか）
+   - Cヘッダ群（`Processing.NDI.*.h`。**`Processing.NDI.Advanced.h`** に圧縮列挙・`NDIlib_compressed_packet_t` が含まれる）
+
+---
+
+## 2. ライブラリとヘッダの差し替え
+
+```bash
+# 1) Advanced SDK の arm64-v8a libndi.so で置き換え
+cp <Advanced-SDK>/lib/android/arm64-v8a/libndi.so \
+   app/src/main/jniLibs/arm64-v8a/libndi.so
+
+# 2) ヘッダを Advanced SDK のもので更新（compressed 列挙・packet 構造体を含む版）
+cp <Advanced-SDK>/include/*.h app/src/main/cpp/include/
+```
+
+> **バージョン整合に注意**：ヘッダと `libndi.so` は同一バージョンに揃えること（現状の同梱はヘッダv6 / libv5.6.1で不一致。Advanced SDKで両方を同一版にする）。
+
+---
+
+## 3. HX3モードを有効化（コードは実装済み）
+
+圧縮パススルー受信の経路は **実装済み** です。有効化はフラグ1つ：
+
+`app/src/main/java/com/example/ndireceiver/ndi/NdiReceiver.kt`
+```kotlin
+// false → 非圧縮(BGRX_BGRA)。true → 圧縮H.264/HEVCパススルー(COMPRESSED_V5)
+const val USE_COMPRESSED_HX = true   // ← Advanced SDK導入後に true へ
+```
+
+これにより受信は `NDIlib_recv_color_format_compressed_v5`(=307) を要求し、HX3フレームが
+`NDIlib_compressed_packet_t` として届き、MediaCodecでハードウェアデコードされます。
+
+### 実装済みの内訳
+
+| レイヤ | ファイル | 内容 |
+|--------|----------|------|
+| Native | `cpp/ndi_wrapper.c` | 圧縮カラーフォーマット(307)へのマッピング、H264/HEVC（高/低帯域）FourCC判定 |
+| Kotlin | `ndi/NdiCompressedPacket.kt` | `NDIlib_compressed_packet_t`(44byteヘッダ)解析、Annex-B組み立て、キーフレーム判定（**単体テスト済み**） |
+| Kotlin | `ndi/NdiReceiver.kt` | 圧縮時はパケット解析→コピー済みAnnex-Bバッファを生成（解放後も安全） |
+| Kotlin | `media/VideoDecoder.kt` | 先頭キーフレーム待ち、`BUFFER_FLAG_KEY_FRAME`付与 |
+| 配線 | `ui/player/PlayerViewModel.kt` | `isCompressed`でMediaCodec経路へ振り分け（既存） |
+
+---
+
+## 4. ビルド
+
+```bash
+./gradlew clean assembleDebug
+./gradlew testDebugUnitTest         # パーサ等の単体テスト
+```
+
+`compileSdk`/NDK/CMake は README「ビルド方法」を参照。
+
+---
+
+## 5. HXテストソースの用意（macOS）
+
+> **Mac版のNDI Tools（Test Pattern等）はフルバンド非圧縮のみ**で、HXは出せません（Screen Capture HXはWindows専用と公式明記）。
+
+確実なHX(圧縮)ソースの作り方：
+
+- **(推奨) Advanced SDK + VideoToolbox で圧縮送信機を自作**：H.264/HEVCにエンコード → Annex-B化 → `NDIlib_compressed_packet_t` に詰めて `NDIlib_send_send_video_v2` で送出。
+  - 参考実装: `satoshi0212/NDIHXSenderSample`（macOS）
+  - 本リポジトリでの非圧縮テスト送信機の作り方は下記「付録」を参照（同じ要領で圧縮版を作成可能）
+- **ハードウェアHX3ソース**：HX3対応カメラ/エンコーダ（BirdDog, PTZOptics HX 等）をLANに接続
+
+---
+
+## 6. 受信テスト手順（実機）
+
+```bash
+ADB=~/Library/Android/sdk/platform-tools/adb
+SER=<your-device-serial>            # adb devices で確認
+$ADB -s $SER install -r app/build/outputs/apk/debug/app-debug.apk
+$ADB -s $SER logcat -c
+# アプリ起動 → ソース選択。以下のログが出れば成功：
+$ADB -s $SER logcat | grep -iE "VideoDecoder|Decoder created|compressed"
+```
+
+確認ポイント：
+- `Decoder created: video/avc|video/hevc WxH`
+- デコード済みフレームが連続描画（OSDで解像度/コーデック表示）
+- 黒画面のままなら §2 のバージョン整合と §3 のフラグ、`logcat` のMediaCodecエラーを確認
+
+---
+
+## 7. 技術メモ（仕様の出典）
+
+- 圧縮受信カラーフォーマット: `NDIlib_recv_color_format_compressed_v5 = 307`（v1=300, v2=301, v3=302, v4=303, v5=307）
+- `NDIlib_compressed_packet_t`：`#pragma pack(1)`・44byteヘッダ・`version_0=44`・レイアウトは `[header][data][extra_data]`
+  - `flags` bit0 = keyframe。`extra_data` はキーフレームにのみ存在
+  - `data`/`extra_data` は **Annex-B（`00 00 00 01` スタートコード付き）**。`extra_data` は H.264: SPS,PPS / HEVC: VPS,SPS,PPS
+  - MediaCodecには **config NAL（extra_data）を先頭**に置く必要があるため、キーフレームでは `extra_data + data` の順で結合
+- FourCC: `H264`=0x34363248 / `HEVC`=0x43564548（高帯域・大文字）、`h264`/`hevc`（低帯域・小文字）
+- 出典: docs.ndi.video「Using H.264, H.265, and AAC Codecs」「Receiving (Advanced SDK)」、`Processing.NDI.Advanced.h`
+
+---
+
+## 8. 未確認事項（正直な現状）
+
+- 本ガイドの§2〜§6は **Advanced SDK 入手後に未実施**。申請許可が下りていないため、**実機でのHX3受信テストはまだ行えていません**。
+- HX3実機テスト後に判明し得る調整点（MediaCodecのプロファイル/レベル対応、10bit/HDR、Annex-Bの3byte/4byteスタートコード差異、解像度切替時の再構成 等）は、テスト時に追記する。
+
+---
+
+## 付録: 非圧縮テスト送信機（検証で使用したもの）
+
+検証では、UnrealのlibndiとリポジトリのNDIヘッダを使い、Mac上に非圧縮BGRA送信機を自作して受信を確認しました。圧縮版もこれを土台に作成できます（VideoToolboxでエンコード→Annex-B→`NDIlib_compressed_packet_t`）。
+
+```c
+// 概略（非圧縮版）。NDIlib_send_create → BGRAフレームを NDIlib_send_send_video_v2 で送出。
+// 圧縮版は FourCC を H264/HEVC にし、p_data を NDIlib_compressed_packet_t にする。
+```

--- a/ndi-dev-status.md
+++ b/ndi-dev-status.md
@@ -1,6 +1,19 @@
 # NDI HX3 Development Status
 
-**Last Updated:** 2026-01-31
+**Last Updated:** 2026-06-04
+
+## Current Phase: 実機検証実施 — 非圧縮OK / HX3はAdvanced SDK待ち
+
+### 2026-06-04 実機検証＆HX3経路実装
+- ✅ 実機(Pixel 7a)でビルド・インストール・起動・**非圧縮NDI(BGRA)受信表示を確認**（Macのテスト送信機）
+- ✅ 切断/再接続 安定、単体テスト全通過
+- ✅ HX3圧縮パススルー経路を実装（`COMPRESSED_V5`要求 / `NDIlib_compressed_packet_t`解析 / MediaCodec配線 / 単体テスト）— ブランチ `claude/hx3-compressed-mediacodec`
+- ⛔ **HX3は未検証**：同梱は無料の標準SDK(5.6.1)で圧縮データを渡せない。**NDI Advanced SDK の申請・入手が必要**（無料・開発用途）。手順は `docs/HX3-INTEGRATION.md`
+- ⛔ Advanced SDK差し替え後の実機HX3テストは**申請許可待ちのため未実施**
+
+---
+
+## （以下は 2026-01-31 時点の記録）
 
 ## Current Phase: ALL COMPLETE - Ready for Device Testing
 


### PR DESCRIPTION
## 概要

NDI|HX3（圧縮 H.264/HEVC）を実機でハードウェアデコード受信するための経路を実装し、あわせて**現状ステータスをリポジトリに明記**しました。実機(Pixel 7a)で検証できる範囲は検証済みです。

## 実機検証で分かったこと

| 項目 | 結果 |
|------|------|
| ビルド / インストール / 起動 | ✅ |
| **非圧縮NDI(BGRA)受信・表示** | ✅ 実機で表示確認（Macテスト送信機 1280×720 BGRA@30fps） |
| 切断・再接続 / 単体テスト | ✅ 安定・全通過 |
| **HX3(圧縮)受信** | ⛔ **未検証**（理由は下記） |

## なぜHX3が現状動かないか

同梱の `libndi.so` は**無料の標準SDK(5.6.1)**で、**圧縮H.264/HEVCをアプリに渡せません**（公式仕様）。HX3のパススルー＆デコードは **NDI Advanced SDK 専用**。
→ HX3対応には **Advanced SDKの申請・入手が必須**（開発用途は無料）。手順は \`docs/HX3-INTEGRATION.md\`。

## このPRの実装

- **native** (`ndi_wrapper.c`): 圧縮カラーフォーマット(`COMPRESSED_V5`=307)へのマッピング、H264/HEVC高・低帯域FourCC判定
- **`NdiCompressedPacket.kt`**: `NDIlib_compressed_packet_t`(44byteヘッダ)解析→Annex-B組み立て・キーフレーム/コーデック判定（**単体テスト付き**）
- **`NdiReceiver.kt`**: `USE_COMPRESSED_HX`フラグ（**既定false**）で圧縮要求を切替。圧縮時はコピー済みバッファ生成（ネイティブ解放後も安全）
- **`VideoDecoder.kt`**: 先頭キーフレーム待ち＋`BUFFER_FLAG_KEY_FRAME`
- **配線**: `PlayerViewModel`が`isCompressed`でMediaCodec経路へ振り分け（既存）
- **docs**: README現状セクション / `docs/HX3-INTEGRATION.md` / `ndi-dev-status.md`更新
- 既存 `PlayerViewModelTest` のコンパイルエラー(Int→FourCC)を修正

> 既定では `USE_COMPRESSED_HX=false` のため**従来の非圧縮動作は不変**（検証済み）。

## 未確認（正直な現状）

- **Advanced SDK 入手後のHX3実機テストは未実施**（申請許可待ち）。SDK差し替え→`USE_COMPRESSED_HX=true`→ビルド→実機受信確認、が次ステップ。

## テスト計画
- [x] `./gradlew assembleDebug`
- [x] `./gradlew testDebugUnitTest`（パーサ単体テスト含む）
- [x] 実機: 非圧縮受信・表示・切断のリグレッション
- [ ] 実機: HX3圧縮受信（**Advanced SDK入手後**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)